### PR TITLE
Bugfix: #143 | Fix cloudflare, inspectlet, and clarity csp issue

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,7 +24,6 @@ app.use(
           "https://*.inspectlet.com",
           "https://challenges.cloudflare.com",
           "https://*.clarity.ms",
-          "https://fonts.googleapis.com",
           "https://*.cloudflareinsights.com"
         ],
         scriptSrcElem: [
@@ -56,7 +55,9 @@ app.use(
           "https://www.google-analytics.com",
           "https://*.clarity.ms",
           "https://*.inspectlet.com",
-          "https://*.cloudflareinsights.com"
+          "https://*.cloudflareinsights.com",
+          "wss://*.clarity.ms",
+          "wss://*.inspectlet.com"
         ],
         imgSrc: ["'self'", "data:", "https:"],
         frameSrc: [

--- a/app.js
+++ b/app.js
@@ -21,21 +21,21 @@ app.use(
           "'self'",
           "'unsafe-inline'",
           "https://www.googletagmanager.com",
-          "https://cdn.inspectlet.com",
+          "https://*.inspectlet.com",
           "https://challenges.cloudflare.com",
-          "https://www.clarity.ms",
+          "https://*.clarity.ms",
           "https://fonts.googleapis.com",
-          "https://static.cloudflareinsights.com"
+          "https://*.cloudflareinsights.com"
         ],
         scriptSrcElem: [
           "'self'",
           "'unsafe-inline'",
           "https://www.googletagmanager.com",
-          "https://cdn.inspectlet.com",
+          "https://*.inspectlet.com",
           "https://challenges.cloudflare.com",
-          "https://www.clarity.ms",
           "https://fonts.googleapis.com",
-          "https://static.cloudflareinsights.com"
+          "https://*.cloudflareinsights.com",
+          "https://*.clarity.ms"
         ],
         styleSrc: [
           "'self'",
@@ -53,7 +53,10 @@ app.use(
         ],
         connectSrc: [
           "'self'",
-          "https://www.google-analytics.com"
+          "https://www.google-analytics.com",
+          "https://*.clarity.ms",
+          "https://*.inspectlet.com",
+          "https://*.cloudflareinsights.com"
         ],
         imgSrc: ["'self'", "data:", "https:"],
         frameSrc: [


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Improved reliability of third‑party analytics and session insights by allowing their subdomains in the Content Security Policy (CSP).
- Security
  - Relaxed CSP directives to permit scripts and connections from subdomains of Inspectlet, Microsoft Clarity, and Cloudflare Insights, reducing blocked requests and supporting websocket connections.
- Chores
  - Updated CSP configuration formatting and ordering for resilience to provider endpoint changes, with no impact on core app functionality.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->