### PR TITLE
Bugfix: #149 | Fixed the issue with Comment deletion and Refactor privilege checks to use CONSTANTS.PRIVILEGE_LEVELS_ENUM across admin and main routes

### DIFF
--- a/server/routes/main.js
+++ b/server/routes/main.js
@@ -405,7 +405,7 @@ router.get('/post/:id', genericOpenRateLimiter, async (req, res) => {
         }
 
         const isCaptchaEnabled = res.locals.siteConfig.isCaptchaEnabled && !!res.locals.siteConfig.cloudflareSiteKey && !!res.locals.siteConfig.cloudflareServerKey;
-        const isCurrentUserAModOrAdmin = currentUser && (currentUser.privilegeLevel === utils.PRIVILEGE_LEVELS_ENUM.ADMIN || currentUser.privilegeLevel === utils.PRIVILEGE_LEVELS_ENUM.MODERATOR);
+        const isCurrentUserAModOrAdmin = currentUser && (currentUser.privilege === CONSTANTS.PRIVILEGE_LEVELS_ENUM.WEBMASTER || currentUser.privilege === CONSTANTS.PRIVILEGE_LEVELS_ENUM.MODERATOR);
         if (currentUser || data.isApproved) {
             res.render('posts', {
                 locals,
@@ -911,7 +911,7 @@ router.post('/post/:id/post-comments', commentsRateLimiter, async (req, res) => 
  * @failure {500} Redirects back to the post page with flash message if deletion fails due to server error
  * 
  * @security
- * @access Restricted to users with ADMIN or MODERATOR privileges
+ * @access Restricted to users with WEBMASTER or MODERATOR privileges
  * @rateLimited Prevents abuse via repeated deletion requests
  * @csrfToken Must be submitted via site forms
  * 
@@ -935,7 +935,7 @@ router.post('/post/delete-comment/:commentId', genericAdminRateLimiter, async (r
         }
         // check if user is authorized to delete the comment
         const currentUser = await getUserFromCookieToken(req);
-        const isCurrentUserAModOrAdmin = currentUser && (currentUser.privilegeLevel === PRIVILEGE_LEVELS_ENUM.ADMIN || currentUser.privilegeLevel === PRIVILEGE_LEVELS_ENUM.MODERATOR);
+        const isCurrentUserAModOrAdmin = currentUser && (currentUser.privilege === CONSTANTS.PRIVILEGE_LEVELS_ENUM.WEBMASTER || currentUser.privilege === CONSTANTS.PRIVILEGE_LEVELS_ENUM.MODERATOR);
         if (!isCurrentUserAModOrAdmin) {
             console.error({ "status": "403", "message": "Unauthorized to delete comment" });
             return res.status(403).redirect('/admin');

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -16,7 +16,20 @@ const CONSTANTS = Object.freeze({
   CLAMP_COMMENT_MIN: 1,
   CLAMP_COMMENT_MAX: 50,
   EMAIL_REGEX: /^[a-zA-Z0-9][a-zA-Z0-9._%+-]*[a-zA-Z0-9]@[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?(\.[a-zA-Z0-9]([a-zA-Z0-9-]*[a-zA-Z0-9])?)*\.[a-zA-Z]{2,}$/,
-  TAGS_REGEX: /[^a-zA-Z0-9-_]/g
+  TAGS_REGEX: /[^a-zA-Z0-9-_]/g,
+  /**
+  * Enum for privilege levels used to determine user roles.
+  * @readonly
+  * @enum {number}
+  * @property {number} WEBMASTER - Full administrative privileges (level 1)
+  * @property {number} MODERATOR - Moderation privileges (level 2)
+  * @property {number} EDITOR - Can write and submit content (level 3)
+  */
+  PRIVILEGE_LEVELS_ENUM: {
+      WEBMASTER : 1,
+      MODERATOR : 2,
+      EDITOR: 3
+    }
 });
 
 module.exports = { CONSTANTS };

--- a/utils/validations.js
+++ b/utils/validations.js
@@ -7,20 +7,6 @@
 const sanitizeHtml = require('sanitize-html');
 const {CONSTANTS} = require('./constants')
 
-/**
- * Enum for privilege levels used to determine user roles.
- * @readonly
- * @enum {number}
- * @property {number} WEBMASTER - Full administrative privileges (level 1)
- * @property {number} MODERATOR - Moderation privileges (level 2)
- * @property {number} WRITER - Can write and submit content (level 3)
- */
-const PRIVILEGE_LEVELS_ENUM = {
-  WEBMASTER : 1,
-  MODERATOR : 2,
-  WRITER: 3
-}
-exports.PRIVILEGE_LEVELS_ENUM = PRIVILEGE_LEVELS_ENUM;
 
 /**
  * Validates a given URI string to ensure it's well-formed and safe.
@@ -69,7 +55,7 @@ exports.isWebMaster = (currentUser) => {
   if (!currentUser) {
     return false;
   }
-  return typeof currentUser.privilege === 'number' && currentUser.privilege === PRIVILEGE_LEVELS_ENUM.WEBMASTER;
+  return typeof currentUser.privilege === 'number' && currentUser.privilege === CONSTANTS.PRIVILEGE_LEVELS_ENUM.WEBMASTER;
 };
 
 /**

--- a/views/admin/edit-user.ejs
+++ b/views/admin/edit-user.ejs
@@ -14,7 +14,7 @@
     <input type="hidden" name="_csrf" value="<%= csrfToken %>">
     <label for="name">Name</label>
     <input type="text" id="name" name="name" value="<%= selectedUser.name %>" required placeholder="user name" required>
-        <label for="privilege">Privilege (1 -&gt; webmaster, 2 -&gt; Moderator, 3 -&gt; writer/editor): </label><br>
+        <label for="privilege">Privilege (1 -&gt; webmaster, 2 -&gt; Moderator, 3 -&gt; Editor): </label><br>
         <input type="number" id="privilege" name="privilege" value="<%= selectedUser.privilege %>" min="1" max="3"
             required>
         <br><br>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Bug Fixes
  - Updated access control to use Webmaster/Moderator roles for viewing post details and deleting comments.

- Refactor
  - Unified privilege checks across admin routes to use centralized constants; removed legacy enum references.

- Documentation
  - Updated role terminology in comments and annotations from Writer/Admin to Editor/Webmaster.

- Style
  - Revised “Edit User” form label to clarify privilege levels (1 Webmaster, 2 Moderator, 3 Editor).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->